### PR TITLE
Add AI-ready GitHub Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,124 @@
+name: Bug (AI-ready)
+description: Report a defect with reproducible steps and expected behavior.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        This template is optimized for coding-AI execution.
+        Please include reproducible details and clear expected behavior.
+
+        **Execution constraints**
+        - Work branch: `agent/shiniclaw-work`
+        - Do not push directly to `master`
+        - Local workflow: `make up`, `make test`, `make down`
+
+  - type: input
+    id: summary
+    attributes:
+      label: Bug summary
+      placeholder: Login succeeds but redirects to a 500 page for admin users.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical (blocking)
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behavior
+      placeholder: Describe what currently happens.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: Describe what should happen instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start stack with `make up`
+        2. Open `http://127.0.0.1:8087/login`
+        3. Log in as admin
+        4. Observe error on redirect
+    validations:
+      required: true
+
+  - type: dropdown
+    id: reproducibility
+    attributes:
+      label: Reproducibility
+      options:
+        - Always
+        - Often
+        - Sometimes
+        - Once
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      value: |
+        - Repo: DragonSymfonyCodex
+        - Local URL: http://127.0.0.1:8087/
+        - Setup used: Docker local (`make setup` / `make up`)
+        - Branch tested:
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / stack traces / screenshots
+      description: Paste relevant logs and stack traces.
+      render: shell
+
+  - type: textarea
+    id: suspected-area
+    attributes:
+      label: Suspected area/files (optional)
+      placeholder: |
+        - src/Controller/SecurityController.php
+        - templates/security/login.html.twig
+        - config/packages/security.yaml
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Fix acceptance criteria
+      placeholder: |
+        - [ ] Bug no longer reproducible with listed steps
+        - [ ] Regression test added/updated
+        - [ ] Existing test suite passes (`make test`)
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification performed after fix
+      placeholder: |
+        - Commands run:
+        - URLs tested:
+        - Tests added/updated:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,123 @@
+name: Feature (AI-ready)
+description: Propose a new feature with enough detail for a coding AI to implement safely.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for opening a feature request.
+
+        This repository is typically implemented by a coding AI.
+        Please be specific and testable.
+
+        **Execution constraints**
+        - Work branch: `agent/shiniclaw-work`
+        - Do not push directly to `master`
+        - Use local Docker workflow (`make up`, `make test`, `make down`)
+
+  - type: input
+    id: goal
+    attributes:
+      label: Goal / Outcome
+      description: One-sentence target outcome.
+      placeholder: Add an admin page showing active world sessions.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What pain/problem exists today?
+      placeholder: Users cannot inspect active local sessions without using CLI commands.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the desired implementation at a high level.
+      placeholder: Add /admin/local-sessions with filtering and pagination.
+    validations:
+      required: true
+
+  - type: textarea
+    id: in-scope
+    attributes:
+      label: In scope
+      description: Bullet list of what should be included.
+      placeholder: |
+        - New admin controller action
+        - Twig template for listing sessions
+        - Functional tests for access + rendering
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope (non-goals)
+      description: What should explicitly NOT be done in this issue?
+      placeholder: |
+        - No realtime websockets
+        - No UI redesign beyond minimal Bootstrap styling
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Use a checklist. Each item must be objectively verifiable.
+      placeholder: |
+        - [ ] Admin can open /admin/local-sessions
+        - [ ] Non-admin users are denied access
+        - [ ] List shows session id, world, actor count, status
+        - [ ] Tests pass in local workflow
+    validations:
+      required: true
+
+  - type: textarea
+    id: technical-notes
+    attributes:
+      label: Technical notes / constraints
+      description: Known constraints, architecture notes, migration concerns.
+      placeholder: |
+        Symfony 8, Doctrine ORM, Twig + Bootstrap frontend.
+        Keep changes compatible with current Docker-based local dev setup.
+
+  - type: textarea
+    id: files-likely
+    attributes:
+      label: Files/areas likely affected
+      description: Optional but helpful for faster implementation.
+      placeholder: |
+        - src/Controller/Admin/*
+        - templates/admin/*
+        - tests/Functional/*
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification steps
+      description: Commands/checks to confirm completion.
+      value: |
+        - `make test`
+        - If UI is touched: verify locally at `http://127.0.0.1:8087/`
+        - Add/adjust tests for changed behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: definition-of-done
+    attributes:
+      label: Definition of done
+      description: Final completion checklist.
+      placeholder: |
+        - [ ] Implementation matches scope and acceptance criteria
+        - [ ] Tests updated and passing
+        - [ ] No direct changes to master branch
+        - [ ] PR description includes summary + test evidence
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor-chore.yml
+++ b/.github/ISSUE_TEMPLATE/refactor-chore.yml
@@ -1,0 +1,95 @@
+name: Refactor / Chore (AI-ready)
+description: Track non-feature work like refactors, maintenance, cleanup, and technical debt.
+title: "[Chore]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for internal improvements that don't primarily add user-facing functionality.
+
+        **Execution constraints**
+        - Work branch: `agent/shiniclaw-work`
+        - Do not push directly to `master`
+        - Verify with local Docker workflow and tests
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Work type
+      options:
+        - Refactor
+        - Chore
+        - Tech debt
+        - CI / tooling
+        - Documentation
+    validations:
+      required: true
+
+  - type: input
+    id: area
+    attributes:
+      label: Target area
+      placeholder: Doctrine repositories for world simulation queries.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / current pain
+      placeholder: Explain why this work is needed now.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      placeholder: |
+        - Extract duplicated query logic into shared method
+        - Rename service for clearer intent
+        - Keep behavior unchanged
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Backward compatibility, migration concerns, performance requirements, etc.
+      placeholder: Public API and DB schema must remain unchanged.
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and rollback plan
+      placeholder: |
+        Risks:
+        - Hidden behavior coupling in existing services
+
+        Rollback:
+        - Revert PR commit(s)
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] Behavior remains unchanged (or explicitly documented)
+        - [ ] Code is simpler/clearer with reduced duplication
+        - [ ] Tests pass and coverage for touched paths remains adequate
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification steps
+      value: |
+        - `make test`
+        - Run any affected Symfony commands manually if relevant
+        - Confirm no unintended UI/API behavior changes
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
Add structured GitHub Issue Forms tailored for this repo and coding-AI execution:

- Feature template (`feature.yml`)
- Bug template (`bug.yml`)
- Refactor/Chore template (`refactor-chore.yml`)
- Config allowing blank issues (`config.yml`)

## Notes
- Keeps blank issues enabled (`blank_issues_enabled: true`) per request
- Includes repository-specific execution constraints and verification fields

## Files
- `.github/ISSUE_TEMPLATE/feature.yml`
- `.github/ISSUE_TEMPLATE/bug.yml`
- `.github/ISSUE_TEMPLATE/refactor-chore.yml`
- `.github/ISSUE_TEMPLATE/config.yml`
