### PR TITLE
Build Encore assets in CI tests

### DIFF
--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -25,6 +25,11 @@ jobs:
       with:
         php-version: '8.4'
     - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+        cache-dependency-path: package-lock.json
     - name: Copy .env.test.local
       run: php -r "file_exists('.env.test.local') || copy('.env.test', '.env.test.local');"
     - name: Cache Composer packages
@@ -35,8 +40,12 @@ jobs:
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
           ${{ runner.os }}-php-
-    - name: Install Dependencies
+    - name: Install PHP dependencies
       run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+    - name: Install JS dependencies
+      run: npm ci
+    - name: Build frontend assets
+      run: npm run build
     - name: Create Database
       run: |
         mkdir -p data

--- a/config/packages/webpack_encore.yaml
+++ b/config/packages/webpack_encore.yaml
@@ -38,7 +38,3 @@ framework:
 #        # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
 #        # Available in version 1.2
 #        cache: true
-
-#when@test:
-#    webpack_encore:
-#        strict_mode: false


### PR DESCRIPTION
### Motivation
- The previous change disabled Encore `strict_mode` in `test`, which hid missing frontend assets and let template rendering pass in CI despite not matching production behavior.  
- Build assets in CI instead so `encore_entry_*` Twig helpers have a real `public/build/entrypoints.json` and tests exercise the real asset pipeline.

### Description
- Added `actions/setup-node@v4` to the `symfony-tests` GitHub Actions job with `node-version: '22'` and npm caching using `package-lock.json`.  
- Added `npm ci` and `npm run build` steps before running `vendor/bin/phpunit` so Encore outputs are generated.  
- Renamed the composer step title to `Install PHP dependencies` for clarity.  
- Removed the `when@test` override that set `webpack_encore.strict_mode: false` from `config/packages/webpack_encore.yaml` so strict behavior is preserved.

### Testing
- Performed repository inspections and pattern searches using `rg`/`sed` to verify the workflow changes and the removal of the `when@test` override, which succeeded.  
- Ran `git diff --check` and fixed a trailing newline issue, and commits were created successfully.  
- Did not run `vendor/bin/phpunit` locally in this environment; CI will exercise the full pipeline (including `npm ci` and `npm run build`) on the next run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69903bf8921c8333afa3f82b4c177d16)